### PR TITLE
Provided Toolchain Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Fatso supports the following build systems:
 - Plain GNU Make (TODO)
 - SCons (TODO)
 - bjam (TODO)
-- Custom scripts (TODO)
+- Custom scripts
 
 Fatso is still in very early stages of development.
 
@@ -47,7 +47,7 @@ Fatso will automatically detect the toolchain your project is using. If it fails
 to detect it, or your project needs special care while building, you have two
 options:
 
-1. Tell Fatso about it, by setting `toolchain: <build command>` in your
+1. Tell Fatso about it, by setting `toolchain: <build commands>` in your
    `fatso.yml`. Fatso will set the CFLAGS/LDFLAGS environment variables with
    the necessary options to build against your local Fatso environment, so if
    your build tool takes those into account, you should be fine.

--- a/internal.h
+++ b/internal.h
@@ -135,7 +135,7 @@ struct fatso_package {
   char* name;
   struct fatso_version version;
   char* author;
-  char* toolchain; // TODO: Autodetect
+  char* toolchain;
   struct fatso_source* source; // TODO: Multiple sources
   struct fatso_configuration base_configuration;
   FATSO_ARRAY(struct fatso_configuration) configurations;

--- a/toolchain.c
+++ b/toolchain.c
@@ -1,6 +1,9 @@
 #include "fatso.h"
 #include "internal.h"
 
+#include <string.h> // strdup
+#include <stdlib.h> // system
+
 typedef int(*init_toolchain_t)(struct fatso_toolchain*);
 typedef bool(*guess_toolchain_t)(const char* path);
 
@@ -20,9 +23,65 @@ static const struct init_named_toolchain named_toolchains[] = {
   {NULL, NULL}
 };
 
+
+
+static int build_provided_toolchain( struct fatso* f, struct fatso_package* p, fatso_report_progress_callback_t progress, const struct fatso_process_callbacks* stdio_callbacks){
+
+  if( p->toolchain == NULL ){
+    // error
+    return -1;
+  }
+
+  int r = 0;
+
+  progress(f, p, p->toolchain, 0, 1);
+  r = fatso_system_with_callbacks( p->toolchain, stdio_callbacks );
+  if( r != 0 ){
+    fatso_logf(f, FATSO_LOG_FATAL, "Error during %s.", p->toolchain);
+    goto out;
+  }
+  progress(f, p, p->toolchain, 1, 1);
+
+out:
+
+  return r;
+}
+
+static int install_provided_toolchain( struct fatso* f, struct fatso_package* p, fatso_report_progress_callback_t progress, const struct fatso_process_callbacks* stdio_callbacks){
+
+  if( p->toolchain == NULL ){
+    // error
+    return -1;
+  }
+
+  int r = 0;
+
+  progress(f, p, p->toolchain, 0, 1);
+  r = fatso_system_with_callbacks( p->toolchain, stdio_callbacks );
+  if( r != 0 ){
+    fatso_logf(f, FATSO_LOG_FATAL, "Error during %s.", p->toolchain);
+    goto out;
+  }
+  progress(f, p, p->toolchain, 1, 1);
+
+out:
+
+  return r;
+}
+
+
 int
 fatso_guess_toolchain(struct fatso* f, struct fatso_package* p, struct fatso_toolchain* out_toolchain) {
-  // TODO: Use 'toolchain' option in package.
+
+  if( p->toolchain != NULL ){
+    fatso_logf(f, FATSO_LOG_INFO, "Using explicitly provided toolchain '%s'.", p->toolchain );
+
+    // TODO: optionally set this to p->toolchain
+    out_toolchain->name = "[config provided]";
+    out_toolchain->build = &build_provided_toolchain;
+    out_toolchain->install = &install_provided_toolchain;
+    return 0; // we found the toolchain
+  }
 
   char* path = fatso_package_build_path(f, p);
   bool found = false;

--- a/toolchain.c
+++ b/toolchain.c
@@ -1,9 +1,6 @@
 #include "fatso.h"
 #include "internal.h"
 
-#include <string.h> // strdup
-#include <stdlib.h> // system
-
 typedef int(*init_toolchain_t)(struct fatso_toolchain*);
 typedef bool(*guess_toolchain_t)(const char* path);
 


### PR DESCRIPTION
Added support for provided toolchains by invoking fatso_system_with_callbacks with exact content of `config.toolchain`. This bypasses the attempt to guess the toolchain, because `config.toolchain` is set.

Question before this gets merged: in `fatso_guess_toolchain`: `out_toolchain->name` is currently set to `"[config provided]"`, the other options are `fatso_package->toolchain`, or another string. Is this the best choice?
